### PR TITLE
Fix : filter callbacks by Id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,14 @@ class Tempus {
 
   add(callback, priority = 0) {
     this.tempusId++
-    this.callbacks.push({ callback, priority, id: this.tempusId})
+    this.callbacks.push({ callback, priority, id: this.tempusId })
     this.callbacks.sort((a, b) => a.priority - b.priority)
 
     return () => this.remove(this.tempusId)
   }
 
   remove(tempusId) {
-    this.callbacks = this.callbacks.filter(({ id }) =>  tempusId !== id )
+    this.callbacks = this.callbacks.filter(({ id }) => tempusId !== id)
   }
 
   raf = (now) => {

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,10 @@ class Tempus {
     this.callbacks.push({ callback, priority, id: this.tempusId})
     this.callbacks.sort((a, b) => a.priority - b.priority)
 
-    return () => this.remove({callback, tempusId: this.tempusId})
+    return () => this.remove({tempusId: this.tempusId})
   }
 
-  remove({callback, tempusId}) {
+  remove({tempusId}) {
     this.callbacks = this.callbacks.filter(({ id }) =>  tempusId !== id )
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,10 @@ class Tempus {
     this.callbacks.push({ callback, priority, id: this.tempusId})
     this.callbacks.sort((a, b) => a.priority - b.priority)
 
-    return () => this.remove({tempusId: this.tempusId})
+    return () => this.remove(this.tempusId)
   }
 
-  remove({tempusId}) {
+  remove(tempusId) {
     this.callbacks = this.callbacks.filter(({ id }) =>  tempusId !== id )
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,19 +3,21 @@ const isClient = typeof window !== 'undefined'
 class Tempus {
   constructor() {
     this.callbacks = []
+    this.tempusId = 0
     this.now = performance.now()
     requestAnimationFrame(this.raf)
   }
 
   add(callback, priority = 0) {
-    this.callbacks.push({ callback, priority })
+    this.tempusId++
+    this.callbacks.push({ callback, priority, id: this.tempusId})
     this.callbacks.sort((a, b) => a.priority - b.priority)
 
-    return () => this.remove(callback)
+    return () => this.remove({callback, tempusId: this.tempusId})
   }
 
-  remove(callback) {
-    this.callbacks = this.callbacks.filter(({ callback: cb }) => callback !== cb)
+  remove({callback, tempusId}) {
+    this.callbacks = this.callbacks.filter(({ id }) =>  tempusId !== id )
   }
 
   raf = (now) => {
@@ -33,3 +35,4 @@ class Tempus {
 if (!isClient) console.warn('Tempus can be used in client side only')
 
 export default isClient && new Tempus()
+


### PR DESCRIPTION
Removing callback with :
`this.callbacks.filter({callback} => cb !== callback)` can remove callbacks that have been added multiple times. 

https://codepen.io/bluetompon/pen/mdzQKEg

I created ids for each callbacks so they can now be filtered by it