### PR TITLE
Add clock functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ const unsubscribe = Tempus.add(animate)
 unsubscribe()
 ```
 
+### Playback Control
+
+```javascript
+Tempus.pause() // no rafs will be called
+Tempus.play() // resume
+Tempus.restart() // set clock elapsed time to 0
+```
+
 ### React
 
 See [tempus/react](./packages/react/README.md)

--- a/packages/core/src/clock.ts
+++ b/packages/core/src/clock.ts
@@ -1,0 +1,55 @@
+export default class Clock {
+  private startTime = 0
+  elapsed = 0
+  private _isPlaying = false
+  private _deltaTime = 0
+  private needsReset = true
+
+  play() {
+    if (this._isPlaying) return
+    this.startTime = performance.now() - this.elapsed
+    this._isPlaying = true
+  }
+
+  pause() {
+    if (!this._isPlaying) return
+    this._deltaTime = 0
+    this._isPlaying = false
+    this.needsReset = true
+  }
+
+  reset() {
+    this.elapsed = 0
+    this.startTime = 0
+    this._deltaTime = 0
+    this._isPlaying = false
+    this.needsReset = true
+  }
+
+  update(browserTime: number) {
+    if (!this._isPlaying) return
+
+    if (this.needsReset) {
+      this.startTime = browserTime
+      this.needsReset = false
+    } else {
+      const newElapsed = browserTime - this.startTime
+      const newDelta = newElapsed - this.elapsed
+
+      this._deltaTime = newDelta
+      this.elapsed = newElapsed
+    }
+  }
+
+  get time() {
+    return this.elapsed
+  }
+
+  get isPlaying() {
+    return this._isPlaying
+  }
+
+  get deltaTime() {
+    return this._deltaTime
+  }
+}

--- a/packages/core/src/clock.ts
+++ b/packages/core/src/clock.ts
@@ -9,6 +9,7 @@ export default class Clock {
   play() {
     if (this._isPlaying) return
     this._currentTime = 0
+    this._startTime = undefined
     this._isPlaying = true
   }
 
@@ -16,7 +17,6 @@ export default class Clock {
     if (!this._isPlaying) return
     this._deltaTime = 0
     this._isPlaying = false
-    this._startTime = undefined
   }
 
   reset() {

--- a/packages/core/src/tempus.ts
+++ b/packages/core/src/tempus.ts
@@ -25,7 +25,6 @@ class Clock {
 
   pause() {
     if (!this._isPlaying) return
-    // this.elapsed = performance.now() - this.startTime
     this._deltaTime = 0
     this._isPlaying = false
     this.needsReset = true

--- a/packages/core/src/tempus.ts
+++ b/packages/core/src/tempus.ts
@@ -14,8 +14,8 @@ class Clock {
   private startTime: number = 0
   private elapsed: number = 0
   private _isPlaying: boolean = false
-  private lastTime?: number
   private _deltaTime: number = 0
+  private needsReset: boolean = true
 
   play() {
     if (this._isPlaying) return
@@ -25,34 +25,32 @@ class Clock {
 
   pause() {
     if (!this._isPlaying) return
-    this.elapsed = performance.now() - this.startTime
-    this.lastTime = undefined
+    // this.elapsed = performance.now() - this.startTime
     this._deltaTime = 0
     this._isPlaying = false
+    this.needsReset = true
   }
 
   reset() {
     this.elapsed = 0
     this.startTime = 0
-    this.lastTime = undefined
     this._deltaTime = 0
     this._isPlaying = false
+    this.needsReset = true
   }
 
   update(browserTime: number) {
-    if (this._isPlaying) {
-      if (this.lastTime === undefined) {
-        this.lastTime = browserTime
-        this.startTime = browserTime
-      } else {
-        const newElapsed = browserTime - this.startTime
-        const newDelta = browserTime - this.lastTime
-        
-        // Ensure delta time is never larger than elapsed time
-        this._deltaTime = newDelta
-        this.lastTime = browserTime
-        this.elapsed = newElapsed
-      }
+    if (!this._isPlaying) return
+
+    if (this.needsReset) {
+      this.startTime = browserTime
+      this.needsReset = false
+    } else {
+      const newElapsed = browserTime - this.startTime
+      const newDelta = newElapsed - this.elapsed
+
+      this._deltaTime = newDelta
+      this.elapsed = newElapsed
     }
   }
 

--- a/packages/core/src/tempus.ts
+++ b/packages/core/src/tempus.ts
@@ -181,8 +181,6 @@ class TempusImpl {
     const elapsed = this.clock.time
     const deltaTime = this.clock.deltaTime
 
-    console.log('raf >>>', { elapsed, deltaTime })
-
     this.fps = 1000 / deltaTime
 
     const now = performance.now()

--- a/packages/core/src/tempus.ts
+++ b/packages/core/src/tempus.ts
@@ -181,6 +181,8 @@ class TempusImpl {
     const elapsed = this.clock.time
     const deltaTime = this.clock.deltaTime
 
+    console.log('raf >>>', { elapsed, deltaTime })
+
     this.fps = 1000 / deltaTime
 
     const now = performance.now()

--- a/playground/core/test.ts
+++ b/playground/core/test.ts
@@ -78,7 +78,9 @@ function slider() {
 requestAnimationFrame(slider)
 
 Tempus.add(
-  () => {
+  (elapsed, deltaTime) => {
+    // console.log({ elapsed, deltaTime })
+
     const instances = Object.values(Tempus.framerates)
       .flatMap((framerate) =>
         framerate.callbacks.map((callback) => ({
@@ -93,7 +95,7 @@ Tempus.add(
     //   console.log(instance.label, instance.samples)
     // })
 
-    document.querySelector('#app')!.innerHTML = instances
+    document.querySelector('#stats')!.innerHTML = instances
       .map((instance, index) => {
         // let duration = instance.samples.at(-1)
         const duration =
@@ -117,7 +119,7 @@ Tempus.add(
       })
       .join('\n')
 
-    document.querySelector('#app')!.innerHTML +=
+    document.querySelector('#stats')!.innerHTML +=
       `<br/><div>fps: ${Math.round(Tempus?.fps ?? 0)} (${Math.floor(
         Tempus.usage * 100
       )}%)</div>`
@@ -141,3 +143,27 @@ Tempus.add(() => {
   frameCount++
   frameCount %= 2
 })
+
+const playpauseBtn = document.createElement('button')
+playpauseBtn.textContent = 'Play/Pause'
+playpauseBtn.style.marginRight = '10px'
+playpauseBtn.onclick = () => {
+  console.log('was playing?', Tempus.isPlaying)
+  if (Tempus.isPlaying) {
+    Tempus.pause()
+    playpauseBtn.textContent = 'Play'
+  } else {
+    Tempus.play();
+    playpauseBtn.textContent = 'Pause';
+  }
+};
+
+const restartBtn = document.createElement('button')
+restartBtn.textContent = 'Restart'
+restartBtn.onclick = () => {
+  console.log('restarting')
+  Tempus.restart()
+}
+
+document.querySelector('#app')!.appendChild(playpauseBtn)
+document.querySelector('#app')!.appendChild(restartBtn)

--- a/playground/core/test.ts
+++ b/playground/core/test.ts
@@ -1,6 +1,6 @@
 import Tempus from 'tempus'
 
-function isPrime(num) {
+function isPrime(num: number) {
   if (num < 2) return false
   for (let i = 2; i * i <= num; i++) {
     if (num % i === 0) return false
@@ -8,7 +8,7 @@ function isPrime(num) {
   return true
 }
 
-function sumPrimes(limit) {
+function sumPrimes(limit: number) {
   let sum = 0
   for (let i = 2; i <= limit; i++) {
     if (isPrime(i)) {
@@ -155,10 +155,10 @@ playpauseBtn.onclick = () => {
     Tempus.pause()
     playpauseBtn.textContent = 'Play'
   } else {
-    Tempus.play();
-    playpauseBtn.textContent = 'Pause';
+    Tempus.play()
+    playpauseBtn.textContent = 'Pause'
   }
-};
+}
 
 const restartBtn = document.createElement('button')
 restartBtn.textContent = 'Restart'

--- a/playground/core/test.ts
+++ b/playground/core/test.ts
@@ -122,7 +122,9 @@ Tempus.add(
     document.querySelector('#stats')!.innerHTML +=
       `<br/><div>fps: ${Math.round(Tempus?.fps ?? 0)} (${Math.floor(
         Tempus.usage * 100
-      )}%)</div>`
+      )}%)</div>
+      <div>elapsed: ${Tempus.clock.time.toFixed(2)}</div>
+      <div>delta: ${Tempus.clock.deltaTime.toFixed(2)}</div><br/>`
   },
   {
     fps: 2,

--- a/playground/core/test.ts
+++ b/playground/core/test.ts
@@ -147,7 +147,7 @@ Tempus.add(() => {
 })
 
 const playpauseBtn = document.createElement('button')
-playpauseBtn.textContent = 'Play/Pause'
+playpauseBtn.textContent = 'Pause'
 playpauseBtn.style.marginRight = '10px'
 playpauseBtn.onclick = () => {
   console.log('was playing?', Tempus.isPlaying)

--- a/playground/www/pages/core.astro
+++ b/playground/www/pages/core.astro
@@ -6,7 +6,9 @@ import pkg from '../../../packages/core/package.json'
 
 <Layout title={`${pkg.name}`}>
   <div id="debug"></div>
-  <div id="app"></div>
+  <div id="app">
+    <div id="stats" />
+  </div>
   <script src="../../core/test.ts"></script>
   <!-- THESE ARE HERE TO TEST THE BROWSER VERSION BUNDLE -->
   <!-- <script is:raw src="../../node_modules/tempus/dist/tempus.min.js"></script> -->


### PR DESCRIPTION
Add clock functionality so that ticker could be paused and restarted.

This idea comes from an initial need of resetting ticker's elapsed time due to gsap globalTimeline getting it's first tick called with an elapsed time of ~1/2secs (I guess that hydration is responsible for a big part of it). We need to ensure that we are starting our animations from elapsed time 0 to prevent animations being skipped.

Not sure if this is something you also noticed when synching gsap.ticker to tempus, this is the current behavior faking a long blocking task of 1 second 

https://github.com/user-attachments/assets/1b005768-9ecc-41db-86c9-403ba20af5d3

<img width="1240" alt="image" src="https://github.com/user-attachments/assets/6b5ba70e-d2f1-472c-91af-9344df3f8c80" />

[DEMO](https://stackblitz.com/edit/vitejs-vite-pyupnne7?file=src%2Fmain.js)