### PR TITLE
chore: move playground-only deps out of root

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "tsup": "^8.3.6",
-    "typescript": "^5.7.3",
-    "lottie-web": "^5.13.0",
-    "motion": "^12.40.0"
+    "typescript": "^5.7.3"
   },
   "peerDependencies": {
     "react": ">=17.0.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -17,6 +17,8 @@
     "astro": "^5.18.2",
     "tempus": "workspace:*",
     "lorem-ipsum": "^2.0.8",
+    "lottie-web": "^5.13.0",
+    "motion": "^12.40.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "^5.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,12 +15,6 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
-      lottie-web:
-        specifier: ^5.13.0
-        version: 5.13.0
-      motion:
-        specifier: ^12.40.0
-        version: 12.40.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
       tsup:
         specifier: ^8.3.6
         version: 8.3.6(postcss@8.5.15)(typescript@5.7.3)(yaml@2.9.0)
@@ -63,6 +57,12 @@ importers:
       lorem-ipsum:
         specifier: ^2.0.8
         version: 2.0.8
+      lottie-web:
+        specifier: ^5.13.0
+        version: 5.13.0
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1287,11 +1287,6 @@ packages:
 
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
-
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
@@ -3521,8 +3516,8 @@ snapshots:
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
@@ -3841,9 +3836,6 @@ snapshots:
       vscode-uri: 3.1.0
 
   '@vscode/l10n@0.0.18': {}
-
-  acorn@8.14.0:
-    optional: true
 
   acorn@8.17.0: {}
 
@@ -4333,14 +4325,14 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  framer-motion@12.40.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  framer-motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       motion-dom: 12.40.0
       motion-utils: 12.39.0
       tslib: 2.5.0
     optionalDependencies:
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   fsevents@2.3.3:
     optional: true
@@ -4896,13 +4888,13 @@ snapshots:
 
   motion-utils@12.39.0: {}
 
-  motion@12.40.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      framer-motion: 12.40.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      framer-motion: 12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.5.0
     optionalDependencies:
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   mrmime@2.0.1: {}
 
@@ -5038,13 +5030,6 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-
-  react-dom@18.3.1(react@19.0.0):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 19.0.0
-      scheduler: 0.23.2
-    optional: true
 
   react-refresh@0.17.0: {}
 
@@ -5363,7 +5348,7 @@ snapshots:
   terser@5.16.6:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true


### PR DESCRIPTION
## What this does
Moves `lottie-web` and `motion` from the root `devDependencies` into the `playground` workspace, where they're actually used (only `playground/core/test.ts` imports them). Library contributors no longer pull these into the root install, and it's now obvious the published package doesn't touch them.

Re-lands a change that was stranded when #15 merged at an earlier commit.

## Summary
- root `package.json`: remove `lottie-web`, `motion` from devDependencies
- `playground/package.json`: add them to dependencies
- regenerate `pnpm-lock.yaml`

## Test Plan
- [x] `pnpm --filter playground build` green (resolves lottie/motion via the playground workspace)
- [x] `pnpm build` (library) unaffected